### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,12 @@
+{
+  "name": "knockout-js-infinite-scroll",
+  "version": "0.1.0",
+  "main": "infinitescroll.js",
+  "ignore": [
+    ".gitignore",
+    "README.md"
+  ],
+  "dependencies": {
+    "knockout.js": "~3.0.0"
+  }
+}


### PR DESCRIPTION
In order to use this as a bower-package a bower.json is required (this PR adds one), and it is also required to register the package. (http://bower.io/)

Would be thankful if you could merge in and register as a package in bower:

bower register knockout-js-infinite-scroll https://github.com/thinkloop/knockout-js-infinite-scroll

(in case you do not have bower, you can install it by: npm install -g bower)
