### PR TITLE
fix name of dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "version": "0.1.0",
   "main": "infinitescroll.js",
   "dependencies": {
-    "knockout.js": "~3.0.0"
+    "knockout": "~3.0.0"
   },
 
   "ignore": [


### PR DESCRIPTION
I made a mistake. Fixed here.

There needs to be a tag for this version to as tag (that is how bower resolves versions). I.e. you would need to do:

`git tag -a v0.1.0`
`git push --tags`

After that, doing:

`bower info knockout-js-infinite-scroll`

will show there is a version.

Thanks
